### PR TITLE
[ FEAT ] : 게시물 API 추가 및 Refactoring

### DIFF
--- a/drrr-api/src/main/java/com/drrr/techblogpost/controller/TechBlogPostController.java
+++ b/drrr-api/src/main/java/com/drrr/techblogpost/controller/TechBlogPostController.java
@@ -1,11 +1,11 @@
 package com.drrr.techblogpost.controller;
 
 import com.drrr.domain.category.service.CategoryService.CategoryDto;
+import com.drrr.domain.techblogpost.dto.TechBlogPostOuterDto;
 import com.drrr.domain.techblogpost.entity.TechBlogPost;
+import com.drrr.domain.techblogpost.repository.TechBlogPostRepository;
 import com.drrr.techblogpost.dto.TechBlogPostLikeDto;
-import com.drrr.techblogpost.service.ExternalTechBlogPostLikeService;
 import com.drrr.techblogpost.service.ExternalTechBlogPostService;
-import com.drrr.web.security.annotation.UserAuthority;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -15,7 +15,6 @@ import jakarta.validation.constraints.NotNull;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -25,19 +24,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
-@UserAuthority
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1")
 public class TechBlogPostController {
+    private final String ADD = "ADD";
+    private final String DELETE = "REMOVE";
     private final ExternalTechBlogPostService externalTechBlogPostService;
-    private final ExternalTechBlogPostLikeService externalTechBlogPostLikeService;
+    private final TechBlogPostRepository techBlogPostRepository;
+
 
     @Operation(summary = "모든 기술 블로그를 가져오는 API", description = "호출 성공 시 모든 기술 블로그 정보 반환")
     @GetMapping("/posts")
-    public List<TechBlogPost> findAllPosts() {
+    public List<TechBlogPostOuterDto> findAllPosts() {
         return externalTechBlogPostService.execute();
     }
+
 
     @Operation(summary = "특정 카테고리에 해당하는 기술블로그를 가져오는 API", description = "호출 성공 시 특정 카테고리 id에 해당하는 기술 블로그 정보 반환")
     @ApiResponses(value = {
@@ -50,22 +52,20 @@ public class TechBlogPostController {
 
     @Operation(summary = "사용자가 기술 블로그에 좋아요를 누를 때 사용하는 api", description = "호출 성공 시 게시물 좋아요 증가")
     @PostMapping("/post/like")
-    public ResponseEntity<String> addPostLike(@RequestBody @NotNull final TechBlogPostLikeDto request) {
-        externalTechBlogPostService.execute(request, "ADD");
-        return ResponseEntity.ok().build();
+    public void addPostLike(@RequestBody @NotNull final TechBlogPostLikeDto request) {
+        externalTechBlogPostService.execute(request, ADD);
     }
 
     @Operation(summary = "사용자가 기술 블로그에 좋아요 해제할 때 사용하는 api", description = "호출 성공 시 게시물 좋아요 감소")
     @DeleteMapping("/post/like")
-    public ResponseEntity<String> deletePostLike(@RequestBody @NotNull final TechBlogPostLikeDto request) {
-        externalTechBlogPostService.execute(request, "DELETE");
-        return ResponseEntity.ok().build();
+    public void deletePostLike(@RequestBody @NotNull final TechBlogPostLikeDto request) {
+        externalTechBlogPostService.execute(request, DELETE);
     }
 
     @Operation(summary = "조회수가 가장 높은 기술 블로그를 반환 api", description = "호출 성공 시 넘겨준 개수만큼 조회수가 가장 높은 기술 블로그 반환")
-    @DeleteMapping("/post/top/{topN}")
-    public ResponseEntity<String> findTopNPosts(@PathVariable("topN") final int topN) {
-        externalTechBlogPostLikeService.execute(topN);
-        return ResponseEntity.ok().build();
+    @DeleteMapping("/post/top/{count}")
+    public List<TechBlogPost> findTopNPosts(@NotNull @PathVariable("count") final int count) {
+        return techBlogPostRepository.findTopLikePost(count);
     }
+
 }

--- a/drrr-api/src/main/java/com/drrr/techblogpost/controller/TechBlogPostController.java
+++ b/drrr-api/src/main/java/com/drrr/techblogpost/controller/TechBlogPostController.java
@@ -5,6 +5,7 @@ import com.drrr.domain.techblogpost.dto.TechBlogPostOuterDto;
 import com.drrr.domain.techblogpost.entity.TechBlogPost;
 import com.drrr.domain.techblogpost.repository.TechBlogPostRepository;
 import com.drrr.techblogpost.dto.TechBlogPostLikeDto;
+import com.drrr.techblogpost.service.ExternalTechBlogPostLikeService;
 import com.drrr.techblogpost.service.ExternalTechBlogPostService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -31,6 +32,8 @@ public class TechBlogPostController {
     private final String ADD = "ADD";
     private final String DELETE = "REMOVE";
     private final ExternalTechBlogPostService externalTechBlogPostService;
+    private final ExternalTechBlogPostLikeService externalTechBlogPostLikeService;
+
     private final TechBlogPostRepository techBlogPostRepository;
 
 
@@ -64,8 +67,8 @@ public class TechBlogPostController {
 
     @Operation(summary = "조회수가 가장 높은 기술 블로그를 반환 api", description = "호출 성공 시 넘겨준 개수만큼 조회수가 가장 높은 기술 블로그 반환")
     @DeleteMapping("/post/top/{count}")
-    public List<TechBlogPost> findTopNPosts(@NotNull @PathVariable("count") final int count) {
-        return techBlogPostRepository.findTopLikePost(count);
+    public List<TechBlogPostOuterDto> findTopNPosts(@NotNull @PathVariable("count") final int count) {
+        return externalTechBlogPostLikeService.execute(count);
     }
 
 }

--- a/drrr-api/src/main/java/com/drrr/techblogpost/controller/TechBlogPostController.java
+++ b/drrr-api/src/main/java/com/drrr/techblogpost/controller/TechBlogPostController.java
@@ -1,9 +1,8 @@
 package com.drrr.techblogpost.controller;
 
 import com.drrr.domain.category.service.CategoryService.CategoryDto;
+import com.drrr.domain.techblogpost.dto.TechBlogPostInnerDto;
 import com.drrr.domain.techblogpost.dto.TechBlogPostOuterDto;
-import com.drrr.domain.techblogpost.entity.TechBlogPost;
-import com.drrr.domain.techblogpost.repository.TechBlogPostRepository;
 import com.drrr.techblogpost.dto.TechBlogPostLikeDto;
 import com.drrr.techblogpost.service.ExternalTechBlogPostLikeService;
 import com.drrr.techblogpost.service.ExternalTechBlogPostService;
@@ -34,23 +33,28 @@ public class TechBlogPostController {
     private final ExternalTechBlogPostService externalTechBlogPostService;
     private final ExternalTechBlogPostLikeService externalTechBlogPostLikeService;
 
-    private final TechBlogPostRepository techBlogPostRepository;
-
-
     @Operation(summary = "모든 기술 블로그를 가져오는 API", description = "호출 성공 시 모든 기술 블로그 정보 반환")
     @GetMapping("/posts")
     public List<TechBlogPostOuterDto> findAllPosts() {
         return externalTechBlogPostService.execute();
     }
 
-
     @Operation(summary = "특정 카테고리에 해당하는 기술블로그를 가져오는 API", description = "호출 성공 시 특정 카테고리 id에 해당하는 기술 블로그 정보 반환")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "특정 카테고리 id에 해당하는 기술 블로그 정보 반환", content = @Content(schema = @Schema(implementation = CategoryDto.class)))
     })
     @GetMapping("/posts/category/{id}")
-    public List<TechBlogPost> findPostsByCategory(@NotNull @PathVariable("id") final Long id) {
+    public List<TechBlogPostOuterDto> findPostsByCategory(@NotNull @PathVariable("id") final Long id) {
         return externalTechBlogPostService.execute(id);
+    }
+
+    @Operation(summary = "특정 게시물에 대한 상세보기 API", description = "호출 성공 시 특정 게시물에 대한 상세 정보 반환")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "특정 게시물에 대한 상세 정보 반환", content = @Content(schema = @Schema(implementation = CategoryDto.class)))
+    })
+    @GetMapping("/post/{id}")
+    public TechBlogPostInnerDto findPostDetail(@NotNull @PathVariable("id") final Long id) {
+        return externalTechBlogPostService.executeFindPostDetail(id);
     }
 
     @Operation(summary = "사용자가 기술 블로그에 좋아요를 누를 때 사용하는 api", description = "호출 성공 시 게시물 좋아요 증가")

--- a/drrr-api/src/main/java/com/drrr/techblogpost/service/ExternalTechBlogPostLikeService.java
+++ b/drrr-api/src/main/java/com/drrr/techblogpost/service/ExternalTechBlogPostLikeService.java
@@ -1,5 +1,6 @@
 package com.drrr.techblogpost.service;
 
+import com.drrr.domain.techblogpost.dto.TechBlogPostOuterDto;
 import com.drrr.domain.techblogpost.entity.TechBlogPost;
 import com.drrr.domain.techblogpost.service.TechBlogPostService;
 import java.util.List;
@@ -11,8 +12,8 @@ import org.springframework.stereotype.Service;
 public class ExternalTechBlogPostLikeService {
     private final TechBlogPostService techBlogPostService;
 
-    public List<TechBlogPost> execute(final int topN) {
+    public List<TechBlogPostOuterDto> execute(final int count) {
 
-        return techBlogPostService.findTopLikePost(topN);
+        return techBlogPostService.findTopLikePost(count);
     }
 }

--- a/drrr-api/src/main/java/com/drrr/techblogpost/service/ExternalTechBlogPostService.java
+++ b/drrr-api/src/main/java/com/drrr/techblogpost/service/ExternalTechBlogPostService.java
@@ -1,6 +1,7 @@
 package com.drrr.techblogpost.service;
 
 import com.drrr.domain.like.service.TechBlogPostLikeService;
+import com.drrr.domain.techblogpost.dto.TechBlogPostOuterDto;
 import com.drrr.domain.techblogpost.entity.TechBlogPost;
 import com.drrr.domain.techblogpost.service.RedisTechBlogPostService;
 import com.drrr.domain.techblogpost.service.TechBlogPostService;
@@ -16,8 +17,8 @@ public class ExternalTechBlogPostService {
     private final TechBlogPostLikeService techBlogPostLikeService;
     private final RedisTechBlogPostService redisTechBlogPostService;
 
-    public List<TechBlogPost> execute() {
-        return techBlogPostService.findAllPosts();
+    public List<TechBlogPostOuterDto> execute() {
+        return techBlogPostService.findAllPostsOuter();
     }
 
     public List<TechBlogPost> execute(final Long categoryId) {

--- a/drrr-domain-redis/src/main/java/com/drrr/domain/techblogpost/repository/RedisTechBlogPostRepository.java
+++ b/drrr-domain-redis/src/main/java/com/drrr/domain/techblogpost/repository/RedisTechBlogPostRepository.java
@@ -8,4 +8,6 @@ import org.springframework.data.repository.CrudRepository;
 public interface RedisTechBlogPostRepository extends CrudRepository<RedisTechBlogPost, Long> {
     Optional<List<RedisTechBlogPost>> findByIdIn(List<Long> postIds);
 
+    Optional<RedisTechBlogPost> findById(Long postIds);
+
 }

--- a/drrr-domain-redis/src/main/java/com/drrr/domain/techblogpost/service/RedisTechBlogPostService.java
+++ b/drrr-domain-redis/src/main/java/com/drrr/domain/techblogpost/service/RedisTechBlogPostService.java
@@ -29,11 +29,16 @@ public class RedisTechBlogPostService {
 
         final List<RedisTechBlogPost> redisTechBlogPosts = redisTechBlogPostTemplate.opsForValue().multiGet(keys);
 
-        assert redisTechBlogPosts != null;
         return redisTechBlogPosts.stream()
                 .filter(Objects::nonNull)
                 .map(RedisTechBlogPost::getTechBlogPost)
                 .toList();
+    }
+
+    public TechBlogPost findPostByIdInRedis(final Long postId) {
+        //redis repository에서는 찾고자하는 데이터가 없으면 빈 리스트 대신 null를 반환함
+        return redisTechBlogPostRepository.findById(postId).map(RedisTechBlogPost::getTechBlogPost)
+                .orElse(null);
     }
 
     public List<TechBlogPost> findPostsByCategoryIdInRedis(final Long categoryId) {

--- a/drrr-domain/src/main/java/com/drrr/domain/like/entity/TechBlogPostLike.java
+++ b/drrr-domain/src/main/java/com/drrr/domain/like/entity/TechBlogPostLike.java
@@ -27,6 +27,6 @@ public class TechBlogPostLike extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "techblogsdfpost_id")
+    @JoinColumn(name = "techblogpost_id")
     private TechBlogPost post;
 }

--- a/drrr-domain/src/main/java/com/drrr/domain/techblogpost/dto/TechBlogPostInnerDto.java
+++ b/drrr-domain/src/main/java/com/drrr/domain/techblogpost/dto/TechBlogPostInnerDto.java
@@ -1,0 +1,26 @@
+package com.drrr.domain.techblogpost.dto;
+
+import com.drrr.core.code.techblog.TechBlogCode;
+import com.drrr.domain.techblogpost.entity.TechBlogPost;
+import lombok.Builder;
+
+@Builder
+public record TechBlogPostInnerDto(
+        Long id,
+        String title,
+        TechBlogCode techBlogCode,
+        String thumbnailUrl,
+        String aiSummary,
+        String url
+) {
+    public static TechBlogPostInnerDto from(final TechBlogPost post){
+        return TechBlogPostInnerDto.builder()
+                .aiSummary(post.getAiSummary())
+                .techBlogCode(post.getTechBlogCode())
+                .id(post.getId())
+                .thumbnailUrl(post.getThumbnailUrl())
+                .title(post.getTitle())
+                .url(post.getUrl())
+                .build();
+    }
+}

--- a/drrr-domain/src/main/java/com/drrr/domain/techblogpost/dto/TechBlogPostOuterDto.java
+++ b/drrr-domain/src/main/java/com/drrr/domain/techblogpost/dto/TechBlogPostOuterDto.java
@@ -1,0 +1,35 @@
+package com.drrr.domain.techblogpost.dto;
+
+import com.drrr.core.code.techblog.TechBlogCode;
+import com.drrr.domain.techblogpost.entity.TechBlogPost;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.Builder;
+
+@Builder
+public record TechBlogPostOuterDto(
+        Long id,
+        String title,
+        String summary,
+        TechBlogCode techBlogCode,
+        String thumbnailUrl,
+        int viewCount,
+        int postLike,
+        LocalDate writtenAt
+
+) {
+    static public List<TechBlogPostOuterDto> from (final List<TechBlogPost> posts){
+        return posts.stream()
+                .map(post -> TechBlogPostOuterDto.builder()
+                        .title(post.getTitle())
+                        .techBlogCode(post.getTechBlogCode())
+                        .summary(post.getSummary())
+                        .postLike(post.getPostLike())
+                        .thumbnailUrl(post.getThumbnailUrl())
+                        .viewCount(post.getViewCount())
+                        .id(post.getId())
+                        .writtenAt(post.getWrittenAt())
+                        .build())
+                .toList();
+    }
+}

--- a/drrr-domain/src/main/java/com/drrr/domain/techblogpost/repository/CustomTechBlogPostRepository.java
+++ b/drrr-domain/src/main/java/com/drrr/domain/techblogpost/repository/CustomTechBlogPostRepository.java
@@ -1,7 +1,12 @@
 package com.drrr.domain.techblogpost.repository;
 
+import com.drrr.domain.techblogpost.entity.TechBlogPost;
 import java.util.List;
 
 public interface CustomTechBlogPostRepository {
     List<Long> recommendRemain(Long memberId, int remainedPostCount);
+
+    List<TechBlogPost> findPostsByCategory(final Long postId);
+
+    List<TechBlogPost> findTopLikePost(final int count);
 }

--- a/drrr-domain/src/main/java/com/drrr/domain/techblogpost/repository/impl/CustomTechBlogPostRepositoryImpl.java
+++ b/drrr-domain/src/main/java/com/drrr/domain/techblogpost/repository/impl/CustomTechBlogPostRepositoryImpl.java
@@ -2,7 +2,9 @@ package com.drrr.domain.techblogpost.repository.impl;
 
 import static com.drrr.domain.log.entity.post.QMemberPostLog.memberPostLog;
 import static com.drrr.domain.techblogpost.entity.QTechBlogPost.techBlogPost;
+import static com.drrr.domain.techblogpost.entity.QTechBlogPostCategory.techBlogPostCategory;
 
+import com.drrr.domain.techblogpost.entity.TechBlogPost;
 import com.drrr.domain.techblogpost.repository.CustomTechBlogPostRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.List;
@@ -26,6 +28,25 @@ public class CustomTechBlogPostRepositoryImpl implements CustomTechBlogPostRepos
                 .where(memberPostLog.id.isNull())
                 .orderBy(techBlogPost.writtenAt.desc())
                 .limit(remainedPostCount)
+                .fetch();
+    }
+
+    @Override
+    public List<TechBlogPost> findPostsByCategory(Long postId) {
+        return queryFactory.select(techBlogPost)
+                .from(techBlogPostCategory)
+                .leftJoin(techBlogPost)
+                .on(techBlogPostCategory.post.id.eq(techBlogPost.id))
+                .where(techBlogPostCategory.category.id.eq(postId))
+                .fetch();
+    }
+
+    @Override
+    public List<TechBlogPost> findTopLikePost(int count) {
+        return queryFactory.select(techBlogPost)
+                .from(techBlogPost)
+                .orderBy(techBlogPost.postLike.desc(), techBlogPost.writtenAt.desc())
+                .limit(count)
                 .fetch();
     }
 }

--- a/drrr-domain/src/main/java/com/drrr/domain/techblogpost/service/TechBlogPostService.java
+++ b/drrr-domain/src/main/java/com/drrr/domain/techblogpost/service/TechBlogPostService.java
@@ -21,7 +21,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional
 public class TechBlogPostService {
-    private final JPAQueryFactory queryFactory;
     private final TechBlogPostRepository techBlogPostRepository;
     public List<TechBlogPostOuterDto> findAllPostsOuter() {
         final List<TechBlogPost> posts = techBlogPostRepository.findAll();
@@ -71,6 +70,11 @@ public class TechBlogPostService {
             throw TechBlogExceptionCode.TECH_BLOG_NOT_FOUND.newInstance();
         }
         return posts;
+    }
+
+    public TechBlogPost findTechBlogPostsById(final Long postId) {
+        return techBlogPostRepository.findById(1L).orElseThrow(
+                TechBlogExceptionCode.TECH_BLOG_NOT_FOUND::newInstance);
     }
 
 }

--- a/drrr-domain/src/main/java/com/drrr/domain/techblogpost/service/TechBlogPostService.java
+++ b/drrr-domain/src/main/java/com/drrr/domain/techblogpost/service/TechBlogPostService.java
@@ -4,6 +4,7 @@ import static com.drrr.domain.techblogpost.entity.QTechBlogPost.techBlogPost;
 import static com.drrr.domain.techblogpost.entity.QTechBlogPostCategory.techBlogPostCategory;
 
 import com.drrr.core.exception.techblog.TechBlogExceptionCode;
+import com.drrr.domain.techblogpost.dto.TechBlogPostOuterDto;
 import com.drrr.domain.techblogpost.entity.TechBlogPost;
 import com.drrr.domain.techblogpost.repository.TechBlogPostRepository;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -22,23 +23,17 @@ import org.springframework.transaction.annotation.Transactional;
 public class TechBlogPostService {
     private final JPAQueryFactory queryFactory;
     private final TechBlogPostRepository techBlogPostRepository;
-
-    public List<TechBlogPost> findAllPosts() {
+    public List<TechBlogPostOuterDto> findAllPostsOuter() {
         final List<TechBlogPost> posts = techBlogPostRepository.findAll();
         if (posts.isEmpty()) {
             log.error("기술블로그를 찾을 수 없습니다.");
             throw TechBlogExceptionCode.TECH_BLOG_NOT_FOUND.newInstance();
         }
-        return posts;
+        return TechBlogPostOuterDto.from(posts);
     }
 
     public List<TechBlogPost> findPostsByCategory(final Long postId) {
-        final List<TechBlogPost> posts = queryFactory.select(techBlogPost)
-                .from(techBlogPostCategory)
-                .leftJoin(techBlogPost)
-                .on(techBlogPostCategory.post.id.eq(techBlogPost.id))
-                .where(techBlogPostCategory.category.id.eq(postId))
-                .fetch();
+        final List<TechBlogPost> posts = techBlogPostRepository.findPostsByCategory(postId);
         if (posts.isEmpty()) {
             log.error("기술블로그를 찾을 수 없습니다.");
             throw TechBlogExceptionCode.TECH_BLOG_NOT_FOUND.newInstance();
@@ -46,17 +41,13 @@ public class TechBlogPostService {
         return posts;
     }
 
-    public List<TechBlogPost> findTopLikePost(final int topN) {
-        final List<TechBlogPost> topPosts = queryFactory.select(techBlogPost)
-                .from(techBlogPost)
-                .orderBy(techBlogPost.postLike.desc(), techBlogPost.writtenAt.desc())
-                .limit(topN)
-                .fetch();
+    public List<TechBlogPostOuterDto> findTopLikePost(final int count) {
+        final List<TechBlogPost> topPosts = techBlogPostRepository.findTopLikePost(count);
         if (topPosts.isEmpty()) {
             log.error("기술블로그를 찾을 수 없습니다.");
             throw TechBlogExceptionCode.TECH_BLOG_NOT_FOUND.newInstance();
         }
-        return topPosts;
+        return TechBlogPostOuterDto.from(topPosts);
     }
 
     public List<TechBlogPost> findNotCachedTechBlogPosts(final List<TechBlogPost> postsInRedis,


### PR DESCRIPTION
- 게시물을 가져오는 API 에서는 게시물의 간략 보기와 상세 보기를 가져오는 API로 구분함, 그거에 따른 dto 추가 및 반환, ResponseEntity 제거, topN Pathvariable -> count 로 변경
- 반환타입과 메서드 명 변경
- 오타 수정
- 카테고리로 게시물을 찾는 query와 탑 게시물 찾는 커스텀 리포지토리 메서드 추가 및 구현 코드 추가
- 리포지토리에서 바로 가져오려다가 dto로 변환하기 위해서 externalService를 통해서 가져오게 수정
- 매개변수명 수정
- 게시물 상세보기 api 추가
- redis에서 id로 캐시 조회 기능 추가
- id로 게시물 정보 가져오는 서비스 추가
- 게시물 간략해서 보는 dto 추가 및 from 정적 메서드 추가 및 사용